### PR TITLE
MentalStateInterface pom file incremented version number to 1.3.7-SNA…

### DIFF
--- a/mentalStateInterface/pom.xml
+++ b/mentalStateInterface/pom.xml
@@ -54,6 +54,11 @@
 			<id>goalhub-mvn-repo</id>
 			<url>https://raw.github.com/goalhub/mvn-repo/master</url>
 		</repository>
+		
+		<repository>
+			<id>port-mvn-repo</id>
+			<url>https://raw.github.com/tygron-virtual-humans/Integration-mvn-repo/master</url>
+		</repository>
 
 		<repository>
 			<id>eishub-mvn-repo</id>
@@ -65,7 +70,7 @@
 		<dependency>
 			<groupId>com.github.goalhub.grammar</groupId>
 			<artifactId>languageTools</artifactId>
-			<version>1.1.6</version>
+			<version>1.2.0</version>
 		</dependency>
 		
 		<dependency>

--- a/mentalStateInterface/pom.xml
+++ b/mentalStateInterface/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.github.goalhub.mentalstate</groupId>
 	<artifactId>mentalstateinterface</artifactId>
-	<version>1.3.6</version>
+	<version>1.3.7-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Mental State Interface definition</name>


### PR DESCRIPTION
pom file changed so maven dependencies on this repository will be resolved to this fork in tygron-virtual-humans instead of the base repo in goalhub. pom file in runtime can be updated now to same version number
