### PR TITLE
Updated dependencies in other mentalState repos

### DIFF
--- a/mentalStateFactory/pom.xml
+++ b/mentalStateFactory/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.github.goalhub.mentalstate</groupId>
 	<artifactId>mentalstatefactory</artifactId>
-	<version>1.1.6</version>
+	<version>1.1.7-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Mental State Factory</name>
@@ -66,13 +66,13 @@
 		<dependency>
 			<groupId>com.github.goalhub.mentalstate.mentalstateimpl</groupId>
 			<artifactId>swiprologmentalstate</artifactId>
-			<version>1.3.6</version>
+			<version>1.3.7-SNAPSHOT</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>com.github.goalhub.mentalstate</groupId>
 			<artifactId>mentalstateinterface</artifactId>
-			<version>1.3.6</version>
+			<version>1.3.7-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/mentalStateImpl/swiPrologMentalState/pom.xml
+++ b/mentalStateImpl/swiPrologMentalState/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.github.goalhub.mentalstate.mentalstateimpl</groupId>
 	<artifactId>swiprologmentalstate</artifactId>
-	<version>1.3.6</version>
+	<version>1.3.7-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>SWI Prolog implementation of MentalState</name>
@@ -77,13 +77,13 @@
 		<dependency>
 			<groupId>com.github.goalhub.grammar</groupId>
 			<artifactId>languageTools</artifactId>
-			<version>1.1.6</version>
+			<version>1.2.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.github.goalhub.mentalstate</groupId>
 			<artifactId>mentalstateinterface</artifactId>
-			<version>1.3.6</version>
+			<version>1.3.7-SNAPSHOT</version>
 		</dependency>
 		
 		<dependency>

--- a/mentalStateInterface/pom.xml
+++ b/mentalStateInterface/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.github.goalhub.mentalstate</groupId>
 	<artifactId>mentalstateinterface</artifactId>
-	<version>1.3.7-SNAPSHOT</version>
+	<version>1.3.8-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Mental State Interface definition</name>


### PR DESCRIPTION
MentalStateFactory and SWIPrologMentalState depend on MentalStateInterface
